### PR TITLE
Qt crash fix, Skip download fix, Return & parameter types

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -4,118 +4,129 @@ from yt_dlp import YoutubeDL
 import json
 import initialize
 import time
+from PyQt6.QtCore import QObject, pyqtSignal
 
-def download_liked_videos(app):
-    videos = load_liked_videos_from_json()
 
-    for v in videos:
-        if app.cancel_download:
-            print("Download process canceled.")
-            break
+class DownloadWorker(QObject):
+    progress = pyqtSignal(str)
+    finished = pyqtSignal()
+
+    def __init__(self, app):
+        super().__init__()
+        self.app = app
+        self.cancel_download = False
+
+
+    def run(self):
+        videos = self.load_liked_videos_from_json()
+
+        for v in videos:
+            if self.cancel_download:
+                self.progress.emit("Download process canceled.")
+                break
+            try:
+                artist = f"{v['artist']}"
+                song_title = f"{v['song_title']}"
+                file_name = f"{v['song_title']}.%(ext)s"
+
+                parent_directory = initialize.get_directory_path()
+                artist_directory = os.path.join(parent_directory, artist)
+                album_directory = os.path.join(artist_directory, song_title)
+
+                os.makedirs(album_directory, exist_ok=True)
+
+                output_path = os.path.join(album_directory, file_name)
+
+                # Check if song already exists in path
+                if any(os.path.exists(os.path.join(album_directory, f"{v['song_title']}{ext}")) for ext in ['.mp3', '.m4a', '.webm', '.opus', '.mp4', '.flac']):
+                    self.progress.emit(f"File for {v['song_title']} already exists. Skipping download.")
+                    continue
+                
+                self.progress.emit(f"Starting download: {artist} - {song_title}")
+                self.download_video_with_retries(v['video_id'], output_path, song_title)
+                time.sleep(5) 
+            except Exception as e:
+                pass
+        self.progress.emit("Download process complete.")
+
+
+    def download_video_with_retries(self, video_id: str, output_path: str, video_title: str, retries=3, wait=5) -> None:
+        for attempt in range (0, retries):
+            try:
+                self.progress.emit(f"Attempt {attempt} to download: {video_title}")
+                self.download_video(video_id, output_path, video_title)
+                self.progress.emit(f"Successfully downloaded: {video_title}")
+                return
+            except Exception as e:
+                self.progress.emit(f"Error on attempt {attempt} for {video_title}: {e}")
+                if attempt < retries:
+                    self.progress.emit(f"Retrying in {wait} seconds...")
+                    time.sleep(wait)
+                else:
+                    self.progress.emit(f"Failed to download {video_title} after {retries} attempts.")
+
+
+    def download_video(self, video_id: str, output_path: str, video_title: str, format='bestaudio') -> None:
+        ydl_opts = {
+            'format': 'bestaudio[ext!=webm]/best[ext!=webm]',
+            'outtmpl': output_path,
+            'quiet': True,
+            'noplaylist': False,
+            'extractaudio': True,
+            'reject': ['webm'],
+            'postprocessors': [
+                {'key': 'FFmpegMetadata'},
+                {'key': 'EmbedThumbnail'},
+            ],
+            'writethumbnail': True,
+            'ffmpeg_location': r'C:\Users\lealj\OneDrive\Documents\GitHub\DownAndSync\ffmpeg\bin'
+        }
+
         try:
-            artist = f"{v['artist']}"
-            song_title = f"{v['song_title']}"
-            file_name = f"{v['song_title']}.%(ext)s"
-
-            parent_directory = initialize.get_directory_path()
-            artist_directory = os.path.join(parent_directory, artist)
-            album_directory = os.path.join(artist_directory, song_title)
-
-            os.makedirs(album_directory, exist_ok=True)
-
-            output_path = os.path.join(album_directory, file_name)
-
-            # Check if song already exists in path
-            if any(os.path.exists(os.path.join(album_directory, f"{file_name}{ext}")) for ext in ['.mp3', '.m4a', '.webm', '.opus']):
-                print(f"File for {v['title']} already exists. Skipping download.")
-                continue
-            
-            print(f"Starting download: {artist} - {song_title}")
-            download_video_with_retries(v['video_id'], output_path, song_title)
-            time.sleep(5) 
+            with YoutubeDL(ydl_opts) as ydl:
+                result = ydl.download([f"https://www.youtube.com/watch?v={video_id}"])
+                if result == 0:
+                    self.progress.emit(f"{video_title} downloaded successfully.")
+                else:
+                    self.progress.emit(f"Issue downloading {video_title}.")
         except Exception as e:
-            pass
-    print("Download process complete.")
+            import traceback
+            error_details = traceback.format_exc()
+            self.progress.emit(f"Error downloading video {video_title}: {e}\nDetails: {error_details}")
 
 
-def download_video_with_retries(video_id, output_path, video_title, retries=3, wait=5):
-    for attempt in range (0, retries):
+    def load_liked_videos_from_json(self, file_path='liked_videos.json') -> None:
+        """
+        Loads the liked videos from a JSON file into a Python data structure (list).
+        """
         try:
-            print(f"Attempt {attempt} to download: {video_title}")
-            download_video(video_id, output_path, video_title)
-            print(f"Successfully downloaded: {video_title}")
-            return
+            with open(file_path, 'r') as json_file:
+                liked_videos = json.load(json_file)
+            self.progress.emit(f"Loaded {len(liked_videos)} liked videos from {file_path}.")
+            return liked_videos
+        
         except Exception as e:
-            print(f"Error on attempt {attempt} for {video_title}: {e}")
-            if attempt < retries:
-                print(f"Retrying in {wait} seconds...")
-                time.sleep(wait)
-            else:
-                print(f"Failed to download {video_title} after {retries} attempts.")
+            self.progress.emit(f"Error loading liked videos: {e}")
+            return []
 
 
-# TODO: Make ffmpeg_location dynamic
-def download_video(video_id, output_path, video_title, format='bestaudio'):
-    ydl_opts = {
-        'format': 'bestaudio[ext!=webm]/best[ext!=webm]',
-        'outtmpl': output_path,
-        'quiet': True,
-        'noplaylist': False,
-        'extractaudio': True,
-        'reject': ['webm'],
-        'postprocessors': [
-            {'key': 'FFmpegMetadata'},
-            {'key': 'EmbedThumbnail'},
-        ],
-        'writethumbnail': True,
-        'ffmpeg_location': r'C:\Users\lealj\OneDrive\Documents\GitHub\DownAndSync\ffmpeg\bin'
-    }
+    def print_video_download_options(self, video_id: str) -> None:
+        '''
+        Testing - prints download options for the video
+        '''
+        ydl_opts = {
+            'quiet': True,
+            'simulate': True,
+            'format': 'all',
+        }
 
-    try:
-        with YoutubeDL(ydl_opts) as ydl:
-            result = ydl.download([f"https://www.youtube.com/watch?v={video_id}"])
-            if result == 0:
-                print(f"{video_title} downloaded successfully.")
-            else:
-                print(f"Issue downloading {video_title}.")
-    except Exception as e:
-        import traceback
-        error_details = traceback.format_exc()
-        print(f"Error downloading video {video_title}: {e}\nDetails: {error_details}")
-
-
-def load_liked_videos_from_json(file_path='liked_videos.json'):
-    """
-    Loads the liked videos from a JSON file into a Python data structure (list).
-    """
-    try:
-        with open(file_path, 'r') as json_file:
-            liked_videos = json.load(json_file)
-        print(f"Loaded {len(liked_videos)} liked videos from {file_path}.")
-        return liked_videos
-    
-    except Exception as e:
-        print(f"Error loading liked videos: {e}")
-        return []
-
-
-def print_video_download_options(video_id):
-    '''
-    Testing - prints download options for the video
-    '''
-    ydl_opts = {
-        'quiet': True,
-        'simulate': True,
-        'format': 'all',
-    }
-
-    try:
-        with YoutubeDL(ydl_opts) as ydl:
-            print(f"Available download options for video ID: {video_id}")
-            info_dict = ydl.extract_info(f"https://www.youtube.com/watch?v={video_id}", download=False)
-            formats = info_dict.get('formats', [])
-            
-            for f in formats:
-                print(f"Format ID: {f['format_id']}, Extension: {f['ext']}, Resolution: {f.get('resolution', 'N/A')}, Note: {f.get('format_note', 'N/A')}")
-    except Exception as e:
-        print(f"Error fetching download options for video ID {video_id}: {e}")
+        try:
+            with YoutubeDL(ydl_opts) as ydl:
+                self.progress.emit(f"Available download options for video ID: {video_id}")
+                info_dict = ydl.extract_info(f"https://www.youtube.com/watch?v={video_id}", download=False)
+                formats = info_dict.get('formats', [])
+                
+                for f in formats:
+                    self.progress.emit(f"Format ID: {f['format_id']}, Extension: {f['ext']}, Resolution: {f.get('resolution', 'N/A')}, Note: {f.get('format_note', 'N/A')}")
+        except Exception as e:
+            self.progress.emit(f"Error fetching download options for video ID {video_id}: {e}")

--- a/initialize.py
+++ b/initialize.py
@@ -9,11 +9,11 @@ DEFAULT_CONFIG = {
 }
 
 
-def ensure_config_directory():
+def ensure_config_directory() -> None:
     os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
 
 
-def initialize_config():
+def initialize_config() -> None:
     ensure_config_directory()
     if not os.path.exists(CONFIG_FILE):
         with open(CONFIG_FILE, 'w') as file:
@@ -21,7 +21,7 @@ def initialize_config():
         print(f"Default config.json created at {CONFIG_FILE}")
 
 
-def load_config():
+def load_config() -> dict:
     if os.path.exists(CONFIG_FILE):
         with open(CONFIG_FILE, 'r') as file:
             return json.load(file)
@@ -34,13 +34,13 @@ def get_directory_path():
     return directory_path
 
 
-def save_config(data):
+def save_config(data) -> None:
     with open(CONFIG_FILE, 'w') as file:
         json.dump(data, file, indent=4)
     print(f"Config saved to {CONFIG_FILE}")
 
 
-def get_directory_path():
+def get_directory_path() -> str:
     if os.path.exists(CONFIG_FILE):
         with open(CONFIG_FILE, 'r') as file:
             config = json.load(file)

--- a/spotify_api.py
+++ b/spotify_api.py
@@ -8,7 +8,7 @@ REDIRECT_URI = "http://localhost:8080/callback"
 
 scope = "user-library-read"
 
-def spotify_authentication():
+def spotify_authentication() -> spotipy.Spotify:
     sp = spotipy.Spotify(auth_manager=SpotifyOAuth(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -17,7 +17,7 @@ def spotify_authentication():
     ))
     return sp
     
-def get_liked_songs(creds, ):
+def get_liked_songs(creds, ) -> None:
     results = creds.current_user_saved_tracks()
     for idx, item in enumerate(results['items']):
         track = item['track']

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -8,7 +8,7 @@ import json
 # Scopes define the access the app needs.
 SCOPES = ['https://www.googleapis.com/auth/youtube.readonly']
 
-def youtube_authentication():
+def youtube_authentication() -> Credentials:
     """
     Handles YouTube OAuth 2.0 authentication.
     """
@@ -48,11 +48,11 @@ def youtube_authentication():
 
 
 # More efficient way to manage liked videos
-def fetch_liked_videos(creds, output_file='liked_videos.json'):
+def fetch_liked_videos(creds, output_file='liked_videos.json') -> list:
     """
     Fetches the user's liked videos using the YouTube Data API, continuing to make requests until all liked videos are fetched.
     """
-    def sanitize_start(value):
+    def sanitize_start(value: str) -> str:
         """
         Santize song title and artist name, so that they don't start with invalid characters.
         For creating files later without error.


### PR DESCRIPTION
Qt terminal messages required using self.progress.emit, not print().
Downloading process did not skip already present files, due to failing to update key in json object; fixed.
Function parameter types added to some functions. Return types added to functions.